### PR TITLE
Add missing page aliases

### DIFF
--- a/modules/ROOT/pages/appendices/release_notes.adoc
+++ b/modules/ROOT/pages/appendices/release_notes.adoc
@@ -1,4 +1,6 @@
 = Release Notes
+:page-aliases: release_notes.adoc
+
 :dav4jvm-url: https://gitlab.com/bitfireAT/dav4jvm
 :okhttp-url: http://square.github.io/okhttp/
 

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting
 :toc: right
+:page-aliases: troubleshooting.adoc
+
 :owncloud-android-support-mail: android-app@owncloud.com
 :owncloud-github-android-repo-url: https://github.com/owncloud/android
 :owncloud-central-url: https://central.owncloud.org/


### PR DESCRIPTION
Add missing page aliases

Backport to 2.18

(Note, this repo is currently not actively embedded into docs, but will be done soon. This PR is a test that everything in this repo works well including the upcoming backports. The aliases missing must be added anyways 😄 ) 