### PR TITLE
Correct the pdf branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -17,7 +17,7 @@ def main(ctx):
     # Version branches never deploy themselves, but instead trigger a deployment in deployment_branch
     # This must not be changed in version branches
     deployment_branch = default_branch
-    pdf_branch = default_branch
+    pdf_branch = base_branch
 
     return [
         checkStarlark(),


### PR DESCRIPTION
This PR fixes the pdf build for 2.19

No backport, 2.19 only