### PR TITLE
site.yml attribute fix

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-android-version: 2.19
-    previous-android-version: 2.18
+    latest-android-version: '2.19'
+    previous-android-version: '2.18'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
References: https://github.com/owncloud/docs/pull/4647

Adding single quotes to attribute values

Backport to 2.19 and 2.18