### PR TITLE
[2.18] [PR 55] chore: replace s3 server in drone config by secret

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -163,7 +163,7 @@ def build(ctx, environment, latest_version, deployment_branch, base_branch, pdf_
                 "image": "plugins/s3-sync",
                 "settings": {
                     "bucket": "uploads",
-                    "endpoint": "https://doc.owncloud.com",
+                    "endpoint": from_secret("docs_s3_server"),
                     "access_key": from_secret("docs_s3_access_key"),
                     "secret_key": from_secret("docs_s3_secret_key"),
                     "path_style": "true",


### PR DESCRIPTION
Backport of PR #55