### PR TITLE
Setting the description attribute

### DIFF
--- a/modules/ROOT/pages/accounts.adoc
+++ b/modules/ROOT/pages/accounts.adoc
@@ -3,9 +3,15 @@
 
 :app-name: ownCloud Android App
 
+:description: This guide describes how to manage user accounts in your Android App. Initially the path to the accounts section isn't visible and you have to open it first.
+
 == Introduction
 
-Initially the path to the accounts section isn't visible. To get to it, first click the btn:[down arrow], in the user details section, which will replace the _"All Files"_ and _"Uploads"_ buttons with _"Add account"_ and _"Manage accounts"_.
+{description}
+
+== Open the Accounts Section
+
+To open the accounts section, first click the btn:[down arrow], in the user details section, which will replace the _"All Files"_ and _"Uploads"_ buttons with _"Add account"_ and _"Manage accounts"_.
 
 image:accounts/manage-user-accounts.png[{app-name}: Manage user accounts, width=40%,pdfwidth=40%]
 

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -10,6 +10,12 @@
 :apache-docs-logging: http://httpd.apache.org/docs/current/logs.html
 :mitmproxy-url: https://mitmproxy.org/
 
+:description: This is a brief troubleshooting guide which will help you to get the data needed necessary for identifying the root cause.
+
+== Introduction
+
+{description}
+
 == Log Files
 
 Effectively debugging software requires as much relevant information as can be obtained. To assist the ownCloud support personnel, please try to provide as many relevant logs as possible. Log output can help with tracking down problems and, if you report a bug, log output can help to resolve an issue more quickly.

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -10,7 +10,7 @@
 :apache-docs-logging: http://httpd.apache.org/docs/current/logs.html
 :mitmproxy-url: https://mitmproxy.org/
 
-:description: This is a brief troubleshooting guide which will help you to get the data needed necessary for identifying the root cause.
+:description: This is a brief troubleshooting guide which will help you get the data necessary for identifying the root cause.
 
 == Introduction
 

--- a/modules/ROOT/pages/connecting.adoc
+++ b/modules/ROOT/pages/connecting.adoc
@@ -6,9 +6,11 @@
 :oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
 :document-provider-url: https://developer.android.com/guide/topics/providers/document-provider
 
+:description: This section describes how to connect the {app-name} to your ownCloud.
+
 == Introduction
 
-This section describes how to connect the {app-name} to your ownCloud.
+{description}
 
 == Physical Location of User Files
 

--- a/modules/ROOT/pages/document_provider.adoc
+++ b/modules/ROOT/pages/document_provider.adoc
@@ -2,10 +2,11 @@
 :toc: right
 
 :app-name: ownCloud Android App
+:description: The Document provider is a feature that comes from the Storage Access Framework provided by Android. It allows a storage service such as ownCloud to reveal the files it manages.
 
 == Introduction
 
-The Document provider is a feature that comes from the Storage Access Framework provided by Android. It allows a storage service (such as owncloud) to reveal the files it manages.
+{description}
 
 == Document Provider Integration
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -7,9 +7,11 @@
 :android-app-tx-url: https://www.transifex.com/owncloud-org/owncloud/android/
 :android-app-beta-url: https://owncloud.com/beta-testing/#android
 
+:description: Here you can find some of the most frequently asked questions about the ownCloud Android app.
+
 == Introduction
 
-Here you can find some of the most frequently asked questions about the ownCloud Android app.
+{description}
 
 == Usage
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,6 +2,7 @@
 
 :app-name: ownCloud Android App
 :keywords: ownCloud, Android
+
 :description: ownCloud's Mobile App for Android offers several key advantages over the web interface. This guide steps you through how to install, configure, use, and troubleshoot it.
 
 Accessing your files on your ownCloud server via the Web interface is easy and convenient. You can use any web browser on any operating system without installing special client software. However, the ownCloud Android app offers several key advantages over the web interface; these include:

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -5,9 +5,11 @@
 :owncloud-mobile-download-url: http://owncloud.org/install/#mobile
 :play-store-url: https://play.google.com/store/apps/details?id=com.owncloud.android
 
+:description: This section describes how to install and upgrade the {app-name}.
+
 == Introduction
 
-This section describes how to install and upgrade the {app-name}.
+{description}
 
 == Installation
 

--- a/modules/ROOT/pages/settings.adoc
+++ b/modules/ROOT/pages/settings.adoc
@@ -2,10 +2,11 @@
 :toc: right
 
 :app-name: ownCloud Android App
+:description: This section describes how to view and control settings in the {app-name}.
 
 == Introduction
 
-This section describes how to view and control settings in the {app-name}.
+{description}
 
 == Settings View
 


### PR DESCRIPTION
This PR sets the description attribute which contents is automatically be used in the meta tag description used by Google/Social Media as short text found when searching/displaying

"Test-Balloon" to see the impact - may take some weeks to see the impact, Google needs to do a rescan first to activate it.

Backport to 2.20 and 2.19