### PR TITLE
Move and update the description attribute to the correct place

### DIFF
--- a/modules/ROOT/pages/accounts.adoc
+++ b/modules/ROOT/pages/accounts.adoc
@@ -1,9 +1,8 @@
 = Manage Users Accounts
 :toc: right
+:description: This guide describes how to manage user accounts in your Android App. Initially the path to the accounts section isn't visible and you have to open it first.
 
 :app-name: ownCloud Android App
-
-:description: This guide describes how to manage user accounts in your Android App. Initially the path to the accounts section isn't visible and you have to open it first.
 
 == Introduction
 
@@ -13,7 +12,7 @@
 
 To open the accounts section, first click the btn:[down arrow], in the user details section, which will replace the _"All Files"_ and _"Uploads"_ buttons with _"Add account"_ and _"Manage accounts"_.
 
-image:accounts/manage-user-accounts.png[{app-name}: Manage user accounts, width=40%,pdfwidth=40%]
+image::accounts/manage-user-accounts.png[{app-name}: Manage user accounts, width=300]
 
 Then, click btn:[Manage accounts]. From there, you can see all of the currently active user accounts, along with a button to add a new account.
 
@@ -29,7 +28,7 @@ After clicking btn:[Manage accounts], you will see a list of the currently activ
 * Change the user's password
 * Remove the account
 
-image:accounts/android-manage-accounts.jpg[{app-name}: Manage existing user accounts, width=40%,pdfwidth=40%]
+image::accounts/android-manage-accounts.jpg[{app-name}: Manage existing user accounts, width=300]
 
 == Removing Accounts & Logging Out
 
@@ -37,7 +36,7 @@ To remove an account, click the btn:[rubbish bin] icon, next to the key icon. Th
 
 This action also logs you out of the server and deletes the database with the list of files. However, any files downloaded onto the device prior to removal will still be there afterwards. You can find them in the public partition.
 
-image:accounts/android-remove-account-confirmation.jpg[{app-name}: Confirm removal of user account, width=40%,pdfwidth=40%]
+image::accounts/android-remove-account-confirmation.jpg[{app-name}: Confirm removal of user account, width=300]
 
 NOTE: When removing an account, the files related to that account are removed automatically. This is also true when uninstalling the app which removes all accounts with their data.
 
@@ -45,6 +44,6 @@ NOTE: When removing an account, the files related to that account are removed au
 
 To change a user's password, click the btn:[key] icon, next to the user's details. This will display the user details page, with the ownCloud server URI and user account, pre-filled. Enter a new password, and click btn:[Connect], and the password will be updated.
 
-image:accounts/android-13.png[{app-name}: Change user password, width=60%,pdfwidth=35%]
+image::accounts/android-13.png[{app-name}: Change user password, width=400]
 
 If you want extra security, please refer to the xref:settings.adoc#passcode-locks-pins[Passcode Locks & Pins] section.

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -1,5 +1,6 @@
 = Troubleshooting
 :toc: right
+:description: This is a brief troubleshooting guide which will help you get the data necessary for identifying the root cause.
 :page-aliases: troubleshooting.adoc
 
 :owncloud-android-support-mail: android-app@owncloud.com
@@ -9,8 +10,6 @@
 :owncloud-docs-server-tracing: https://doc.owncloud.com/server/admin_manual/configuration/server/request_tracing.html
 :apache-docs-logging: http://httpd.apache.org/docs/current/logs.html
 :mitmproxy-url: https://mitmproxy.org/
-
-:description: This is a brief troubleshooting guide which will help you get the data necessary for identifying the root cause.
 
 == Introduction
 
@@ -71,4 +70,4 @@ Please see the {apache-docs-logging}[Apache logging] pages to get more informati
 
 {mitmproxy-url}[mitmproxy] is an interactive man-in-the-middle proxy for HTTP and HTTPS with a console interface. At ownCloud we use it a lot to investigate every detail of HTTP requests and responses.
 
-image:troubleshooting/mitmproxy_screenshot.png[mitmproxy sample output, width=100%,pdfwidth=100%]
+image::troubleshooting/mitmproxy_screenshot.png[mitmproxy sample output, width=400]

--- a/modules/ROOT/pages/connecting.adoc
+++ b/modules/ROOT/pages/connecting.adoc
@@ -1,12 +1,12 @@
 = Connecting to Your ownCloud
 :toc: right
+:description: This section describes how to connect the ownCloud Android App to your ownCloud.
+
 :app-name: ownCloud Android App
 :create-self-signed-ssl-cert: https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-apache-in-ubuntu-16-04
 :enable-ssl-url: http://info.ssl.com/article.aspx?id=10241
 :oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
 :document-provider-url: https://developer.android.com/guide/topics/providers/document-provider
-
-:description: This section describes how to connect the {app-name} to your ownCloud.
 
 == Introduction
 
@@ -30,16 +30,16 @@ The first time you run your ownCloud Android app, it opens to a configuration sc
 Enter your server URL, login name, password, and click the btn:[Connect] button.
 Click the btn:[eyeball] to the right of your password to expose your password.
 
-image:connecting/android-2.png[{app-name}: Add a new account, width=40%,pdfwidth=40%]
+image::connecting/android-2.png[{app-name}: Add a new account, width=250]
 
 For best security, your ownCloud server should be {enable-ssl-url}[SSL-enabled] so that you can connect via HTTPS. The {app-name} will test your connection as soon as you provide it and tell you if you entered it correctly. If your server has {create-self-signed-ssl-cert}[a self-signed SSL certificate], you'll get a warning that it is not to be trusted. If this happens, click the btn:[YES] button to accept the certificate and complete your account setup.
 
-image:connecting/android-3.png[The {app-name}: choose whether to trust SSL certificates that cannot be verified, width=40%,pdfwidth=40%]
+image::connecting/android-3.png[The {app-name}: choose whether to trust SSL certificates that cannot be verified, width=350]
 
 With that completed, you're now ready to use the {app-name}.
 At this point, you'll be on the _"All Files"_ screen, which you see below.
 
-image:connecting/android-all-files-overview.png[{app-name}: All files overview, width=80%,pdfwidth=80%]
+image::connecting/android-all-files-overview.png[{app-name}: All files overview, width=400]
 
 By clicking the main menu at the top left, you will be able to manage the core functionality of the app. The options are:
 

--- a/modules/ROOT/pages/document_provider.adoc
+++ b/modules/ROOT/pages/document_provider.adoc
@@ -1,8 +1,8 @@
 = Document Provider Integration
 :toc: right
+:description: The Document provider is a feature that comes from the Storage Access Framework provided by Android. It allows a storage service such as ownCloud to reveal the files it manages.
 
 :app-name: ownCloud Android App
-:description: The Document provider is a feature that comes from the Storage Access Framework provided by Android. It allows a storage service such as ownCloud to reveal the files it manages.
 
 == Introduction
 
@@ -10,11 +10,11 @@
 
 == Document Provider Integration
 
-image:document-provider/step-1.png[{app-name} Document provider integration - step 1, width=40%,pdfwidth=40%]
+image::document-provider/step-1.png[{app-name} Document provider integration - step 1, width=250]
 
 To use it we only need to open Downloads app in Android 7 and 8 or Files app in Android 9 and select the ownCloud account appearing in the side menu.
 
-image:document-provider/step-2.png[{app-name} Document provider integration - step 2, width=40%,pdfwidth=40%]
+image::document-provider/step-2.png[{app-name} Document provider integration - step 2, width=250]
 
 Once you select the account you will have access to your file list. In there, you can perform the following actions: 
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,13 +1,11 @@
 = Android Frequently Asked Questions (FAQ)
 :toc: right
+:description: Here you can find some of the most frequently asked questions about the ownCloud Android app.
 
-// :hardbreaks:
 :oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
 :android-legacy-central-url: https://central.owncloud.org/t/local-copy-could-not-be-renamed-try-a-different-name/16715/2
 :android-app-tx-url: https://www.transifex.com/owncloud-org/owncloud/android/
 :android-app-beta-url: https://owncloud.com/beta-testing/#android
-
-:description: Here you can find some of the most frequently asked questions about the ownCloud Android app.
 
 == Introduction
 

--- a/modules/ROOT/pages/files.adoc
+++ b/modules/ROOT/pages/files.adoc
@@ -1,27 +1,28 @@
 = Managing Files
 :toc: right
+:description: This section describes how to manage files in the ownCloud Android App.
 
 :app-name: ownCloud Android App
 
 == Introduction
 
-This section describes how to manage files in the {app-name}.
+{description}
 
 == All Files View
 
 When you are in the _"All Files"_ view, all files that you have permission to access on your ownCloud server are displayed in your Android app. However, they are not downloaded until you click on them. Downloaded files are marked with a green tick, on the top-right of the file's icon.
 
-image:files/android-all-files-view.jpg[{app-name}: All files view, width=40%,pdfwidth=40%]
+image::files/android-all-files-view.jpg[{app-name}: All files view, width=250]
 
 NOTE: Videos don’t need to be downloaded before they can be viewed, as they can be streamed to the device from your ownCloud server.
 
 Download and view a file with a short press on the file's name or icon. Then, a short press on the overflow button opens a menu with options for managing your file.
 
-image:files/android-file-overflow-menu.jpg[{app-name}: File list overflow menu, width=40%,pdfwidth=40%]
+image::files/android-file-overflow-menu.jpg[{app-name}: File list overflow menu, width=250]
 
 When you are on your main Files page and you long press on any file or folder a list of options appears, which you can see in the image below. Some of them appear in the top bar. The ones that don't fit in the top bar, appear in the list of options when pressing the overflow button.
 
-image:files/android-file-list-overflow-menu.jpg[{app-name}: File overflow menu, width=40%,pdfwidth=40%]
+image::files/android-file-list-overflow-menu.jpg[{app-name}: File overflow menu, width=150]
 
 NOTE: The file size values differ depending on the client you are using. Some operating systems like iOS and macOS use the decimal system (power of 10) where 1kB or one kilobyte consists of 1000 bytes, while Linux, Android and Windows use the binary system (power of 2) where 1KB consists of 1024 bytes and is called a kibibyte. So no reason to worry if you see different file sizes in ownCloud Web and on your mobile device.
 
@@ -38,7 +39,7 @@ To share a file, you first need to either:
 
 The dialog which appears shows a list of users and groups with whom the file is already shared, as well as a list of one or more public links.
 
-image:files/multiple_share_link.png[{app-name}: File and folder share settings, width=40%,pdfwidth=40%]
+image::files/multiple_share_link.png[{app-name}: File and folder share settings, width=250]
 
 From here you can:
 
@@ -58,7 +59,7 @@ NOTE: If your ownCloud server administrator has enabled username auto-completion
 
 You can create a Federated Share Link by entering the username and remote URL of the person you want to share with in this format: `user@domain.com`. You don't have to guess; the Personal page in the ownCloud Web GUI tells the exact Federated Cloud ID. Just ask them to copy and paste and send it to you.
 
-image:files/android-14.png[{app-name}: Share file with dialog, width=50%,pdfwidth=50%]
+image::files/android-14.png[{app-name}: Share file with dialog, width=350]
 
 To create a public link, click the btn:[plus symbol] next to _"Public Links"_. This will display the options available for that link, including _"Allow editing"_, _"Password"_, and _"Expiration"_. After the options have been suitably configured, click btn:[Save] to create the link.
 If you do not want to create the public link, click btn:[Cancel].
@@ -67,7 +68,7 @@ If you do not want to create the public link, click btn:[Cancel].
 
 If you upload animated GIFs, when viewing them, they will be animated and not render as a still image, as in the example GIF below.
 
-image:files/gif-support-owncloud-android-app.png[View animated GIFs in the ownCloud Android app., width=40%,pdfwidth=40%]
+image::files/gif-support-owncloud-android-app.png[View animated GIFs in the ownCloud Android app., width=250]
 
 == Creating New Content
 
@@ -75,11 +76,11 @@ To add new content to your ownCloud server, whether files, folders, or content f
 
 Then, use the btn:[Upload] button to add files to your ownCloud account from your Android filesystem, from other apps, or from every storage attached to your device
 
-image:files/android-4.png[{app-name}: Upload content, width=40%,pdfwidth=40%]
+image::files/android-4.png[{app-name}: Upload content, width=250]
 
 Click the btn:[overflow button] at the top right (that's the one with three vertical dots) to open a user menu. btn:[Grid view] toggles between grid and list view. btn:[Refresh account] syncs with the server, and btn:[Sort] gives you the option to sort your files by date, or alphabetically.
 
-image:files/android-6.png[{app-name}: User overflow menu, width=40%,pdfwidth=40%]
+image::files/android-6.png[{app-name}: User overflow menu, width=200]
 
 == Upload Pictures Directly From The Camera
 
@@ -88,9 +89,9 @@ image:files/android-6.png[{app-name}: User overflow menu, width=40%,pdfwidth=40%
 | Step 1
 | Step 2
 | Step 3
-a| image::files/share-from-camera-owncloud-android-app-step-1.png[Uploading pictures directly from the camera in the ownCloud Android app - step 1, width=80%,pdfwidth=80%]
-a| image:files/share-from-camera-owncloud-android-app-step-2.png[Uploading pictures directly from the camera in the ownCloud Android app - step 2, width=80%,pdfwidth=80%]
-a| image:files/share-from-camera-owncloud-android-app-step-3.jpg[Uploading pictures directly from the camera in the ownCloud Android app - step 3, width=80%,pdfwidth=80%]
+a| image::files/share-from-camera-owncloud-android-app-step-1.png[Uploading pictures directly from the camera in the ownCloud Android app - step 1, width=200]
+a| image::files/share-from-camera-owncloud-android-app-step-2.png[Uploading pictures directly from the camera in the ownCloud Android app - step 2, width=200]
+a| image::files/share-from-camera-owncloud-android-app-step-3.jpg[Uploading pictures directly from the camera in the ownCloud Android app - step 3, width=200]
 |===
 
 Images can be uploaded directly from the camera. To do so, similar to uploading a file or creating a new folder, when viewing all files, click the btn:[Plus] icon, then the btn:[Upload] button in the popup list (which is the first icon). From there, under btn:[Upload to ownCloud], click btn:[Picture from camera]. The camera app will then start, and the picture that you take can be directly uploaded to your ownCloud server.
@@ -99,13 +100,13 @@ Images can be uploaded directly from the camera. To do so, similar to uploading 
 
 The Android application can perform some operations on multiple files simultaneously, such as refreshing and deleting. To select multiple files, long select the first file that you want to work with; you will see a checkbox appear on the far right-hand side. After that, check the checkbox next to all the other files that you want to perform the same operation on, and then perform the operation.
 
-image:files/select-multiple-files.png[{app-name}: Select multiple files, width=40%,pdfwidth=40%]
+image::files/select-multiple-files.png[{app-name}: Select multiple files, width=250]
 
 == Uploading Files Taken From the Camera
 
 Pictures and videos can be uploaded from your smartphone after choosing the folder where they are stored. To specify where they are located, in the _"Settings"_ options, under xref:settings.adoc#camera-uploads[Camera uploads], enable one of _"Picture uploads"_ or _"Video uploads"_. After that, a further option called _"Camera folder"_ will become visible, as in the screenshot below.
 
-image:files/specify-camera-folder.png[{app-name}: Specify camera folder, width=40%,pdfwidth=40%]
+image::files/specify-camera-folder.png[{app-name}: Specify camera folder, width=250]
 
 == Current Uploads
 
@@ -113,7 +114,7 @@ The Uploads page displays the status of files currently uploading, a list of you
 
 If the upload fails because you're trying to upload to a folder that you do not have permission to access, you will see a _"Permissions error"_. Change the permissions on the folder and retry the upload, or cancel and then upload the file to a different folder.
 
-image:files/current-uploads.png[ownCloud Android app — Current Uploads view, width=40%,pdfwidth=40%]
+image::files/current-uploads.png[ownCloud Android app — Current Uploads view, width=250]
 
 == Make Folders Available Offline
 
@@ -124,5 +125,4 @@ Folders can be made available for when no internet or mobile connectivity is ava
 
 When the folders have been cached locally, the icon will change to be a purple circle with a white tick icon in the bottom right-hand corner, as in the screenshot below.
 
-image:files/files_folders_view.png[ownCloud Android app — Files and Folders view, width=40%,pdfwidth=40%]
-
+image::files/files_folders_view.png[ownCloud Android app — Files and Folders view, width=250]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,8 +1,4 @@
 = The Mobile App for Android
-
-:app-name: ownCloud Android App
-:keywords: ownCloud, Android
-
 :description: ownCloud's Mobile App for Android offers several key advantages over the web interface. This guide steps you through how to install, configure, use, and troubleshoot it.
 
 {description} Accessing your files on your ownCloud server via the Web interface is easy and convenient. You can use any web browser on any operating system without installing special client software. However, the ownCloud Android app offers several key advantages over the web interface; these include:

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -1,11 +1,10 @@
 = Installing the ownCloud Android App
 :toc: right
+:description: This section describes how to install and upgrade the ownCloud Android App.
 
 :app-name: ownCloud Android App
 :owncloud-mobile-download-url: https://owncloud.com/mobile-apps/
 :play-store-url: https://play.google.com/store/apps/details?id=com.owncloud.android
-
-:description: This section describes how to install and upgrade the {app-name}.
 
 == Introduction
 
@@ -17,7 +16,7 @@ One way to get your ownCloud Android app is to log into your ownCloud server fro
 
 The first time you log into a new ownCloud account, you'll see a screen with a download link to the {app-name} in the {play-store-url}[Google Play Store].
 
-image:installation/android-1.png[Download the ownCloud Android app in the Google Play store, width=40%,pdfwidth=40%]
+image::installation/android-1.png[Download the ownCloud Android app in the Google Play store, width=300]
 
 You will also find these links on your Personal page in the ownCloud Web interface. Find source code and more information from the {owncloud-mobile-download-url}[ownCloud download page]. Users of customized ownCloud Android apps, for example from their employer, should follow their employer's instructions.
 
@@ -51,5 +50,5 @@ The new features covered in the wizard are:
 * xref:files.adoc#gif-support[GIF Support]
 * xref:files.adoc#upload-pictures-directly-from-the-camera[Upload Pictures Directly From The Camera]
 
-image:installation/new-features-wizard-step-owncloud-android-app.png[The
-New Features Wizard in the ownCloud Android app., width=80%,pdfwidth=80%]
+image::installation/new-features-wizard-step-owncloud-android-app.png[The
+New Features Wizard in the ownCloud Android app., width=500]

--- a/modules/ROOT/pages/settings.adoc
+++ b/modules/ROOT/pages/settings.adoc
@@ -1,8 +1,8 @@
 = Application Settings
 :toc: right
+:description: This section describes how to view and control settings in the ownCloud Android App.
 
 :app-name: ownCloud Android App
-:description: This section describes how to view and control settings in the {app-name}.
 
 == Introduction
 
@@ -12,13 +12,13 @@
 
 Use the _"Settings"_ screen to control your ownCloud applications settings and functionality.
 
-image:settings/android-settings-page.png[The Settings Screen in the {app-name}, width=40%,pdfwidth=40%]
+image::settings/android-settings-page.png[The Settings Screen in the {app-name}, width=250]
 
 == Camera Uploads
 
 If you take photos or create videos with your Android device, they can be automatically uploaded to your ownCloud server. To enable this, under _"Camera uploads"_ tap _Picture uploads_ or _Video uploads_ or both. The following image shows the settings for the picture upload. The same settings are available on a separate screen for video uploads.
 
-image:settings/android-settings-camera-upload.png[{app-name} settings - picture and video upload configuration, width=40%,pdfwidth=40%]
+image::settings/android-settings-camera-upload.png[{app-name} settings - picture and video upload configuration, width=250]
 
 By enabling these features, any new photos or videos which you create will be automatically uploaded every 15 minutes. Photos and videos are not uploaded when they’re created, to focus on reliability, instead of immediacy, and to avoid battery draining caused by excessive checking of the camera folder.
 
@@ -41,7 +41,7 @@ To create a new folder, click the btn:[More options] menu, in the top right-hand
 
 By enabling the option (which you can see in the screenshot below), the {app-name} will not be obscured by any light filtering apps, which gives the choice of using them together. When it is enabled, security warning is enabled. 
 
-image:settings/allow-light-filtering-apps.png[Allow light filtering apps, width=40%,pdfwidth=40%]
+image::settings/allow-light-filtering-apps.png[Allow light filtering apps, width=250]
 
 == Logs
 
@@ -59,7 +59,7 @@ The following options are available to manage logs:
 
 Note, an automatically running task will remove logs older than a week to keep space requirements small.
 
-image:logs/show-logs-list.png[View logs in the {app-name}, width=40%,pdfwidth=40%]
+image::logs/show-logs-list.png[View logs in the {app-name}, width=250]
 
 To view details or search inside a log file, tap on the respective entry in the log list. Three things can happen:
 
@@ -67,19 +67,19 @@ To view details or search inside a log file, tap on the respective entry in the 
 +
 If this occurs, install a log reading app of your choice.
 +
-image:logs/no-log-reading-app-found.png[No log reading app found, width=40%,pdfwidth=40%]
+image::logs/no-log-reading-app-found.png[No log reading app found, width=250]
 
 . Exactly one log reading app is installed
 +
 The log reading app opens and the log is shown. The example image shows the `Log Viewer` app.
 +
-image:logs/log-viewer-opened.png[Log Viewer opened with log selected, width=40%,pdfwidth=40%]
+image::logs/log-viewer-opened.png[Log Viewer opened with log selected, width=250]
 
 . Select a log reading app from the list of available ones
 +
 After selecting the app, the log is opened by the app selected.
 +
-image:logs/select-log-reading-app.png[Select a logs reading app from the list, width=40%,pdfwidth=40%]
+image::logs/select-log-reading-app.png[Select a logs reading app from the list, width=250]
 
 == Access Protection
 
@@ -100,9 +100,9 @@ In addition to the Passcode Lock and Pins, you also have the ability to use both
 
 NOTE: To use the Fingerprint Lock, the Pattern Lock has to be enabled.
 
-image:security/fingerprint-and-pattern-lock-enabled-disabled-owncloud-android-app.png[Enable or disable the Fingerprint and Pattern Lock in the ownCloud Android app., width=40%,pdfwidth=40%]
+image::security/fingerprint-and-pattern-lock-enabled-disabled-owncloud-android-app.png[Enable or disable the Fingerprint and Pattern Lock in the ownCloud Android app., width=400]
 
-image:security/fingerprint-and-pattern-lock-owncloud-android-app.png[The Pattern Lock and Fingerprint Lock in the ownCloud Android app., width=40%,pdfwidth=40%]
+image::security/fingerprint-and-pattern-lock-owncloud-android-app.png[The Pattern Lock and Fingerprint Lock in the ownCloud Android app., width=250]
 
 After you enable the pattern lock, you will need to create a pattern and then confirm it to access the ownCloud app, just as you would if you've enabled that for access to the phone itself. If you later disable pattern lock, you will need to enter your pattern again.
 


### PR DESCRIPTION
**This is no content change !**

When using the attribute `:description:` which creates a meta tag in htm for search engines when rendered, you need to use two rules:

* It must be under the section header, not in aprticular order, but without a blank line above
* You must not use any links or attributes like `xref:{url}[text]` - will not get resolved and taken as it is

Found by chance. This PR corrects this for the docs-client-android repo.

This will now make search engines print predefined text more likely than before when returning search results.

Additionally fixed image positions and size.

Backport to 3.0