### PR TITLE
Changes necessary for 4.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "3.0"
+    latest_version = "4.0"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -28,8 +28,8 @@ asciidoc:
     idseparator: '-'
     experimental: ''
 #   android
-    latest-android-version: '3.0'
-    previous-android-version: '2.21'
+    latest-android-version: '4.0'
+    previous-android-version: '3.0'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 4.0 branch.

The 4.0 branch is already pushed and prepared and is included in the branch protection rules.

When 4.0 (Android) is finally out, the 2.21 branch can be archived, see step 4 in https://github.com/owncloud/docs-client-android/blob/master/docs/new-version-branch.md

Note, that the 4.0 branch in this repo is already created, but the `latest` pointer on the web
will be set to it automatically when the tag in Android is set. This means, that in the docs homepage, `latest` will point to 3.0 until the tag in Android is set accordingly. When merging this PR, 2.21 will be dropped from the web but is available via pdf as usual.

Note, this PR must be merged before the 4.0 tag in the Android repo is set to avoid a 404 for `latest`.

Note that a PR in docs must be made to announce the 4.0 branch. The docs PR must be merged AFTER this PR is merged to avoid a CI error in docs.

Before merging this PR, we should take care that 2.21 has all changes necessary merged as post
merging the 2.21 pdf is fixed.

@michaelstingl @JuancaG05 fyi

@mmattel @EParzefall @phil-davis
Post merging this, we need to backport all relevant changes to 4.0