### PR TITLE
Changes necessary for the 4.2 branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "4.1"
+    latest_version = "4.2"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 4.2 branch.

* The 4.2 branch is already pushed and prepared and is included in the branch protection rules.

* When 4.2 is finally out, the 4.0 branch can be archived, see step 3 in [Create a New Version Branch](https://github.com/owncloud/docs-client-android/blob/master/docs/new-version-branch.md)

* Note, that the 4.2 branch in this repo is already created, but the `latest` pointer on the web will be set to it automatically when the tag in core is set. This means, that in the docs homepage, `latest` will point to 4.1 until the tag in Android is set accordingly. When merging this PR, 4.0 will be dropped from the web.

* Note that this PR must be merged **before** the 4.2 tag in docs is set to avoid a 404 for `latest`.

* Note before merging this PR, we should take care that 4.0 has all necessary changes merged.

@TheOneRing @JuancaG05 @Aitorbp fyi

@mmattel @EParzefall @phil-davis
Post merging this, we need to backport all relevant changes to 4.2