### PR TITLE
Remove the release notes page

### DIFF
--- a/modules/ROOT/pages/appendices/release_notes.adoc
+++ b/modules/ROOT/pages/appendices/release_notes.adoc
@@ -1,7 +1,0 @@
-= Release Notes
-:page-aliases: release_notes.adoc
-:android-changelog-url: https://github.com/owncloud/android/blob/master/CHANGELOG.md
-
-== Changelog for the Android App
-
-ownCloud provides a full changelog with a summary and details for each release of the Android App. Click the following link to access it at {android-changelog-url}[GitHub].

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -8,4 +8,3 @@
 * xref:faq.adoc[Frequently Asked Questions (FAQ)]
 * xref:appendices/index.adoc[Appendices]
 ** xref:appendices/troubleshooting.adoc[Troubleshooting]
-** xref:appendices/release_notes.adoc[Release Notes]


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/29 (Adding iOS and Android release notes)

Backport to 4.2 and 4.1