### PR TITLE
Update the component-version counting extension

### DIFF
--- a/ext-antora/comp-version.js
+++ b/ext-antora/comp-version.js
@@ -1,18 +1,33 @@
 'use strict'
 
-// Extension to print the component, version and number of files that will be processed 
-
+/**
+ * Print a table of Component - Version - Number of Files + total.
+ * Only the number of files in the modules directory are counted
+ * Version 1.1.0
+ *
+ * ┌─────────┬────────┬─────────┬───────┐
+ * │ (index) │  Name  │ Version │ Files │
+ * ├─────────┼────────┼─────────┼───────┤
+ * │    0    │ 'ROOT' │   '~'   │  14   │
+ * │    3    │        │         │  14   │
+ * └─────────┴────────┴─────────┴───────┘
+ */
+ 
 module.exports.register = function () {
   this.once('contentAggregated', ({ contentAggregate }) => {
     console.log('\nProcessing the following components, versions and number of files\n')
     var total_files = 0
     const component_table = []
       contentAggregate.forEach((bucket) => {
-        component_table.push ({Name: bucket.name, Version: bucket.version || '~', Files: bucket.files.length})
-        total_files += parseInt(bucket.files.length)
+        var count = 0
+        bucket.files.forEach((file) => {
+          if (file.src.path.startsWith('modules')) {
+            count += 1
+          }
+        })
+        component_table.push ({Name: bucket.name, Version: bucket.version || '~', Files: count})
+        total_files += count
       })
-    component_table.length++
-    component_table.length++
     component_table.push ({Files: total_files})
     console.table(component_table)
     console.log() // do not delete, else we get a double empty line


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs/pull/5011 (Update the component-version counting extension)

The original script contained an error in counting files. That aperently catched ones eyes when building local using `site-dev.yml` (`npm run antora-dev-local`). There, the script counted, for an unknown cause, all files of the repo instead only those ones which are in the `modules` directory . This is now fixed and counting is locked to files in the modules directory only independent of the build type.

Backport to 4.3 and 4.4