### PR TITLE
Fix image rendering

### DIFF
--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -50,5 +50,4 @@ The new features covered in the wizard are:
 * xref:files.adoc#gif-support[GIF Support]
 * xref:files.adoc#upload-pictures-directly-from-the-camera[Upload Pictures Directly From The Camera]
 
-image::installation/new-features-wizard-step-owncloud-android-app.png[The
-New Features Wizard in the ownCloud Android app., width=500]
+image::installation/new-features-wizard-step-owncloud-android-app.png[The New Features Wizard in the ownCloud Android app, width=500]


### PR DESCRIPTION
The image in question was not rendered because there was, for an unknown reason, a linebreak in the alt-text.

Fixed now.

Backport to 4.5 and 4.4