### PR TITLE
build: use new source path for the ui and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **IMPORTANT**
 
-Scince April 2026, this repository requires [Commit Signing](https://docs.github.com/articles/about-gpg) and uses [Conventional Commits](https://www.conventionalcommits.org) for commits and the Pull Request title.
+Since April 2026, this repository requires [Commit Signing](https://docs.github.com/articles/about-gpg) and uses [Conventional Commits](https://www.conventionalcommits.org) for commits and the Pull Request title.
 
 **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Android App Documentation
 
+**IMPORTANT**
+
+Scince April 2026, this repository requires [Commit Signing](https://docs.github.com/articles/about-gpg) and uses [Conventional Commits](https://www.conventionalcommits.org) for commits and the Pull Request title.
+
 **Table of Contents**
 
 * [Building the Andriod Docs](#building-the-android-docs)

--- a/site.yml
+++ b/site.yml
@@ -14,7 +14,7 @@ ui:
   output_dir: assets
   bundle:
     snapshot: true
-    url: https://minio.owncloud.com/documentation/ui-bundle.zip
+    url: https://github.com/owncloud/docs-ui/releases/download/latest/ui-bundle.zip
 
 output:
   clean: true


### PR DESCRIPTION
* With the new GH Actions, the ui is now sourced from a different location
* Update the readme to reflect required prerequisites